### PR TITLE
Fix build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,6 @@ import com.jobteaser.pipeline.GithubFlow
 import com.jobteaser.pipeline.packager.DockerPackager
 
 def packager = new DockerPackager()
-  .withTagImageWithBranch(true)
 
 new GithubFlow(this)
   .withPhase('package', packager)


### PR DESCRIPTION
withTagImageWithBranch method was removed and `true` was the default behavior anyways